### PR TITLE
Fixed various bugs

### DIFF
--- a/src/imgarchive.cpp
+++ b/src/imgarchive.cpp
@@ -143,7 +143,7 @@ void IMGArchive::ImportEntries(ArchiveInfo *pInfo)
             }
 
             temp += "\0";
-            if (std::filesystem::path(temp).extension() == "") // skip folder paths
+            if (std::filesystem::is_directory(temp)) // skip folders
             {
                 rootDir = std::move(temp) + "\\";
             }

--- a/src/imgparser.cpp
+++ b/src/imgparser.cpp
@@ -130,9 +130,8 @@ void Parser::Import(IMGArchive *pArc, const std::string &path, bool replace)
         );
     }
 
-    EntryInfo info;
+    EntryInfo info = {0};
     strcpy(info.FileName, name.c_str());
-    info.FileName[23] = '\0';
     info.Path = path;
     info.bImported = true;
     info.Type = IMGArchive::GetFileType(info.FileName);

--- a/src/windialogs.cpp
+++ b/src/windialogs.cpp
@@ -30,16 +30,16 @@ std::string WinDialogs::OpenFile()
 std::string WinDialogs::ImportFiles()
 {
     OPENFILENAME ofn = { sizeof ofn };
-    char file[2048];
-    file[0] = '\0';
-    ofn.lpstrFile = file;
-    ofn.nMaxFile = 2048;
+    ofn.nMaxFile = 1 << 20;
+    ofn.lpstrFile = (LPSTR) calloc(ofn.nMaxFile, 1);
     ofn.hwndOwner = NULL;
     ofn.Flags = OFN_ALLOWMULTISELECT | OFN_EXPLORER;
 
-    if (GetOpenFileName(&ofn))
+    if (ofn.lpstrFile && GetOpenFileName(&ofn))
     {
-        return std::string(ofn.lpstrFile, 2048);
+        std::string paths = std::string(ofn.lpstrFile, ofn.nMaxFile);
+        free(ofn.lpstrFile);
+        return paths;
     }
 
     return "";


### PR DESCRIPTION
- Fixed importing from folders that contain a dot in their name (they were wrongly considered files which broke everything)
- Fixed uninitialised (0xCC) filenames end bytes written to the .dir file that would cause crashes
- Fixed being only able to import ~120 files at a time by making the buffer that contains the list of filenames to import be 1 MB instead of 2 kB (you need 94 kB to import all the files in Vice City's gta3.img at once).